### PR TITLE
Make package available globally when installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name="guided-diffusion",
     py_modules=["guided_diffusion"],
     install_requires=["blobfile>=1.0.5", "torch", "tqdm"],
+    packages=find_packages()
 )


### PR DESCRIPTION
Hi! Made a little edit in setup.py such that the package is available globally when installed. 

Instead of doing this in the diffusion notebooks:

``` python
!git clone https://github.com/crowsonkb/guided-diffusion
!pip install -e ./guided-diffusion
sys.path.append('./guided-diffusion')
```

You can do without manually adding the folder to path, simplifying to just this:

``` python
!pip install git+https://github.com/crowsonkb/guided-diffusion
```