### PR TITLE
Fix setuptools installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 setup(
     name="guided-diffusion",
-    py_modules=["guided_diffusion"],
+    packages=["guided_diffusion"],
     install_requires=["blobfile>=1.0.5", "torch", "tqdm"],
 )


### PR DESCRIPTION
Installing directly from pip isn't working because setup.py lists
'py_modules="guided_diffusion', rather than
'package=["guided_diffusion"]'
